### PR TITLE
Fix for ship disappearing if not placed correctly

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -98,8 +98,12 @@ function makeShipsDraggable(){
         el.addEventListener('drop',e=>{
             e.preventDefault()
             const draggedEl = document.querySelector('.dragging')
-            draggedEl.style.visibility = 'hidden'
-            lastMovedShip = draggedEl.classList[0]
+            const boxShipClass = `.board-box.${draggedEl.classList[0]}`
+            if(document.querySelector(boxShipClass)){
+                draggedEl.style.visibility = 'hidden'
+                lastMovedShip = draggedEl.classList[0]
+            }
+
         })
     })
 }


### PR DESCRIPTION
This fixes issue #2.

Ship will return to its starting location if it was not dropped anywhere on the board.